### PR TITLE
[FIX] TransactionRaw.toJson data serialization fix

### DIFF
--- a/lib/tron/src/models/contract/transaction/transaction_raw.dart
+++ b/lib/tron/src/models/contract/transaction/transaction_raw.dart
@@ -1,9 +1,9 @@
+import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:on_chain/tron/src/address/tron_address.dart';
 import 'package:on_chain/tron/src/exception/exception.dart';
-import 'package:on_chain/tron/src/models/contract/base_contract/base.dart';
 import 'package:on_chain/tron/src/models/contract/account/authority.dart';
+import 'package:on_chain/tron/src/models/contract/base_contract/base.dart';
 import 'package:on_chain/tron/src/models/contract/transaction/transaction_contract.dart';
-import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:on_chain/tron/src/protbuf/decoder.dart';
 import 'package:on_chain/utils/utils.dart';
 
@@ -129,7 +129,7 @@ class TransactionRaw extends TronProtocolBufferImpl {
       'ref_block_hash': BytesUtils.toHexString(refBlockHash),
       'expiration': expiration.toString(),
       'auths': auths?.map((auth) => auth.toJson(visible: visible)).toList(),
-      'data': StringUtils.tryDecode(data),
+      'data': BytesUtils.tryToHexString(data),
       'contract': contract.map((c) => c.toJson(visible: visible)).toList(),
       'scripts': BytesUtils.tryToHexString(scripts),
       'timestamp': timestamp.toString(),

--- a/test/tron/json_buff_serialization_test.dart
+++ b/test/tron/json_buff_serialization_test.dart
@@ -10,11 +10,12 @@ void main() {
 }
 
 void transfer() {
-  test('Transafer', () {
+  test('Transfer', () {
     const Map<String, dynamic> tx = {
       'visible': false,
       'txID':
           '4569d0bc9c0d36785233de45808da24c326b92d22919cc7e81335b57778105f5',
+      "data": "68656c6c6f",
       'raw_data_hex':
           '0a026df02208670960a4a79f751c4080c2f29098325a65080112610a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412300a1541fad447e0017b3b7e707a95f8ce1d2119092ea73e1215418840e6c55b9ada326d211d818c34a994aeced808180170a0edee909832',
       'raw_data': {
@@ -41,6 +42,7 @@ void transfer() {
     expect(transaction.rawData.txID, tx['txID']);
     final deserialize = Transaction.deserialize(transaction.toBuffer());
     expect(deserialize.rawData.txID, transaction.rawData.txID);
+    expect(deserialize.rawData.data, transaction.rawData.data);
   });
 }
 


### PR DESCRIPTION
Hi @mrtnetwork !  
First of all, thanks again for the awesome Dart SDKs for working with blockchains — they are just 🔥

### Description

Recently we faced an issue: when trying to send a transaction with the `data` field filled through the `wallet/broadcasttransaction` endpoint, it was rejected by the node.

### Example with the node error
![imgtrxfix](https://github.com/user-attachments/assets/a34bb21d-0f33-4e7f-988a-35271f86bc9a)

### Problem

As you can see, here the *data* field is encoded in UTF-8, which leads to the node rejecting the transaction.
Instead, it must be encoded in hex.

###  Fix

Ensure that the `data` field inside raw_data is properly hex-encoded before broadcasting.

- [x] fix in TransactionRaw.toJson
- [x] tests updated

