### PR TITLE
Fix(evm): emit `gas` in `ETHTransaction.toEstimate()` when > 0 only

### DIFF
--- a/lib/ethereum/src/transaction/eth_transaction.dart
+++ b/lib/ethereum/src/transaction/eth_transaction.dart
@@ -1108,6 +1108,7 @@ class ETHTransaction {
     return {
       if (from != null) 'from': from?.address,
       if (to != null) 'to': to?.address,
+      if (gasLimit > BigInt.zero) 'gas': '0x${gasLimit.toRadixString(16)}',
       'value': '0x${value.toRadixString(16)}',
       if (data.isNotEmpty) 'data': BytesUtils.toHexString(data, prefix: '0x'),
       if (accessList?.isNotEmpty ?? false)

--- a/test/etherum/transaction_test.dart
+++ b/test/etherum/transaction_test.dart
@@ -77,4 +77,56 @@ void main() {
     expect(decode.serialized, serialized);
     expect(decode.maxPriorityFeePerGas, BigInt.zero);
   });
+
+  /// `toEstimate()` must emit the `gas` field when a gas limit is set, so the
+  /// node estimates against that allowed limit instead of the ~40M block gas
+  /// limit. Without it strict op-geth nodes (e.g. OP Sepolia) reject the
+  /// estimate request with "intrinsic gas too high".
+  test('toEstimate includes gas when gasLimit > 0', () {
+    final from = ETHAddress('0x9771D14139a63561189E190BC808a1Ea160ec52d');
+    final token = ETHAddress('0x5fd84259d66Cd46123540766Be93DFE6D43130D7');
+    // ERC20 transfer(0x4204...81c0, 1000) calldata.
+    final data = BytesUtils.fromHexString(
+      'a9059cbb0000000000000000000000004204711fa7fe0a884ea057987d4e2ac1753181c0'
+      '00000000000000000000000000000000000000000000000000000000000003e8',
+    );
+    final transaction = ETHTransaction(
+      nonce: 17,
+      from: from,
+      type: ETHTransactionType.legacy,
+      to: token,
+      gasLimit: BigInt.from(1000000),
+      data: data,
+      value: BigInt.zero,
+      chainId: BigInt.from(11155420), // OP Sepolia
+      gasPrice: BigInt.from(1500375),
+    );
+
+    final estimate = transaction.toEstimate();
+    expect(estimate['gas'], '0xf4240'); // 1_000_000
+    // the other fields the request relies on are still present.
+    expect(estimate['from'], from.address);
+    expect(estimate['to'], token.address);
+    expect(estimate['value'], '0x0');
+    expect(estimate['data'], BytesUtils.toHexString(data, prefix: '0x'));
+  });
+
+  /// When no gas limit is set (the auto-fill case, where the limit is exactly
+  /// what we're estimating), `gas` must be omitted so the payload is unchanged.
+  test('toEstimate omits gas when gasLimit is zero', () {
+    final transaction = ETHTransaction(
+      nonce: 0,
+      from: ETHAddress('0x9771D14139a63561189E190BC808a1Ea160ec52d'),
+      type: ETHTransactionType.legacy,
+      to: ETHAddress('0x5fd84259d66Cd46123540766Be93DFE6D43130D7'),
+      gasLimit: BigInt.zero,
+      data: const [],
+      value: ETHHelper.toWei('0.01'),
+      chainId: BigInt.from(11155420),
+      gasPrice: BigInt.from(1500375),
+    );
+
+    final estimate = transaction.toEstimate();
+    expect(estimate.containsKey('gas'), isFalse);
+  });
 }


### PR DESCRIPTION
## What

`toEstimate()` now adds a `gas` field to the `eth_estimateGas` payload when
`gasLimit > 0`. When `gasLimit == 0` (auto-fill) the behavior is unchanged.

```dart
if (gasLimit > BigInt.zero) 'gas': '0x${gasLimit.toRadixString(16)}',
```

## Why

Optimism: without `gas`, the node uses the block gas limit (~40M) as the upper bound.
Strict op-geth nodes run an affordability pre-check on that bound
(`40M × gas_price > balance`) and reject the request with `intrinsic gas too
high` — breaking gas estimation for token transfers (legacy and EIP-1559). With
`gas` set, the bound becomes affordable and estimation succeeds.

Verified against live OP Sepolia nodes (identical payload):

| Node | without `gas` | with `gas` |
|------|---------------|------------|
| `sepolia.optimism.io` | ❌ `intrinsic gas too high` | ✅ `0xb173` |
| `optimism-sepolia-rpc.publicnode.com` | ❌ `intrinsic gas too high` | ✅ `0xb173` |

## Important

The error currently shows up on **testnet** (OP Sepolia): its op-geth already
ships the stricter gas estimator. On **mainnet** the node still silently caps the
bound, so there is no error yet. Once the network upgrade reaches mainnet, the
same behavior is expected to appear there too — so we land this fix ahead of
time, as insurance.

On every other geth network the change is safe: `gas` is added only when
`gasLimit` is explicitly set.

## Tests

Tests added in `test/etherum/transaction_test.dart`.